### PR TITLE
[CI/Build] Use mypy matcher for pre-commit CI job

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,6 +14,7 @@ jobs:
       with:
         python-version: "3.12"
     - run: echo "::add-matcher::.github/workflows/matchers/actionlint.json"
+    - run: echo "::add-matcher::.github/workflows/matchers/mypy.json"
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       with:
         extra_args: --all-files --hook-stage manual


### PR DESCRIPTION
We have a mypy matcher that allows github to parse mypy output and inline errors in the diff viewer on github. The config didn't make it over in the conversion to pre-commit. This should restore having mypy errors surfaced more clearly on PRs.
