### PR TITLE
update to matcher and fix termination

### DIFF
--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -48,13 +48,15 @@ class GuidanceBackend(StructuredOutputBackend):
 
         if request_type == StructuredOutputOptions.JSON:
             # TODO: make whitespace_flexible configurable
-            self.serialized_grammar = llguidance.LLMatcher.grammar_from_json_schema(
-                grammar_spec, defaults={
-                    "whitespace_flexible": True,
-                })
+            self.serialized_grammar = \
+                llguidance.LLMatcher.grammar_from_json_schema(
+                    grammar_spec, defaults={
+                        "whitespace_flexible": True,
+                    })
         elif request_type == StructuredOutputOptions.JSON_OBJECT:
-            self.serialized_grammar = llguidance.LLMatcher.grammar_from_json_schema(
-                '{"type": "object"}', defaults={
+            self.serialized_grammar = \
+                llguidance.LLMatcher.grammar_from_json_schema(
+                    '{"type": "object"}', defaults={
                     "whitespace_flexible": True,
                 })
         else:
@@ -65,12 +67,10 @@ class GuidanceBackend(StructuredOutputBackend):
             elif request_type == StructuredOutputOptions.CHOICE:
                 tp = "choice"
             else:
-                logger.error(
-                    "Validation should have already occurred. Please file an issue."
-                )
-                raise ValueError(
-                    f"grammar is not of valid supported types. ({request_type!s})"
-                )
+                logger.error("Validation should have already occurred. "
+                             "Please file an issue.")
+                raise ValueError("grammar is not of valid supported types. "
+                                 f"({request_type!s})")
 
             self.serialized_grammar = llguidance.grammar_from(tp, grammar_spec)
 
@@ -124,8 +124,10 @@ class GuidanceGrammar(StructuredOutputGrammar):
 
         # TODO - Add jump decoding support in the future:
         # self.ll_matcher.compute_ff_bytes() - this should always work
-        # self.ll_matcher.compute_ff_tokens() - this only works for "canonical" tokenizers
-        # for conversion between the two, see https://github.com/guidance-ai/llguidance/blob/main/docs/fast_forward.md
+        # self.ll_matcher.compute_ff_tokens() - this only works for
+        #   "canonical" tokenizers
+        # For conversion between the two, see
+        # https://github.com/guidance-ai/llguidance/blob/main/docs/fast_forward.md
 
         r = self.ll_matcher.consume_tokens(tokens)
 
@@ -134,7 +136,8 @@ class GuidanceGrammar(StructuredOutputGrammar):
         return r
 
     def fill_bitmask(self, bitmask: torch.Tensor, idx: int) -> None:
-        # this will automatically return [EOS] mask if the matcher is stopped or otherwise in an error state
+        # this will automatically return [EOS] mask if the matcher is stopped
+        # or otherwise in an error state
         llguidance_torch.fill_next_token_bitmask(self.ll_matcher, bitmask, idx)
         self.check_error()
 


### PR DESCRIPTION
This updates llguidance to 0.7.3 as well as fixes is_terminated() handling, or rather align it with xgrammar, which only says it terminated after it has seen EOS.

I'm not sure if you want whitespace-flexible on by default - it can be overridden by the user with `"x-guidance": { "whitespace_flexible": false }` in the schema; OpenAI is whitespace flexible, but it really depends on the finetuning of the model. Generally, whitespace flexible is safer.

Will look into breakage in the gbnf->lark translator